### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # NMAPgrapher v0.1a
 A tool to generate graph and other output from NMAP XML files. 
 
-###What is it for?
+### What is it for?
 This tool was primarily intended to easily digest NMAP output for inclusion in penetration testing reports as supplementary information, however feel free to use it as you wish.
 
-###What does it do?
+### What does it do?
 NMAP grapher is currently capable of generating the following outputs:
   - Most and Least Common Services
   - Most and Least Common Ports
@@ -18,7 +18,7 @@ The following output formats are supported:
   - HTML
   - CSV
 
-###Where can I find a complete usage guide?
+### Where can I find a complete usage guide?
 Usage information can be found at http://www.attactics.org/2015/09/nmapgrapher-tool-for-digesting-nmap-xml.html. Even more usage information can be found by running:
 ```NMapgrapher.py -h```
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
